### PR TITLE
Add failing test with redux@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "mocha": "^3.2.0",
     "mock-local-storage": "^1.0.2",
     "nyc": "^10.2.0",
+    "redux": "^4.0.0",
     "rimraf": "^2.6.1"
   },
   "babel": {

--- a/tests/middleware.spec.js
+++ b/tests/middleware.spec.js
@@ -1,6 +1,7 @@
 /* eslint-env node, mocha */
 import { expect } from 'chai';
 import { ActionTypes, syncMiddleware, syncedReducer } from '../src/index';
+import { createStore, applyMiddleware } from 'redux';
 
 const context = typeof window !== 'undefined' ? window : global;
 
@@ -80,4 +81,12 @@ describe('middleware', () => {
 
         expect(store.dispatchedActions).to.have.length(1);
     });
+
+    it('should work with real redux', () => {
+        const reducer = () => {};
+        const middlewares = applyMiddleware(syncMiddleware);
+        const creatingStore = createStore.bind(undefined, reducer, middlewares);
+
+        expect(creatingStore).to.not.throw();
+    })
 });


### PR DESCRIPTION
Redux version >= 4 doesn't allow dispatching actions when constructing a middleware.

> Dispatching while constructing your middleware is not allowed. Other middleware would not be applied to this dispatch.

This adds a test that actually tries to create a real redux store with the `syncMiddleware`.