### PR TITLE
Configure travis to build on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: node_js
 node_js:
  - "node"
 
+os:
+ - linux
+ - windows
+
 install:
  - npm install
  - npm install -g codecov


### PR DESCRIPTION
This adds [windows builds on travis](https://blog.travis-ci.com/2018-10-11-windows-early-release).